### PR TITLE
将 vaporz 的 work 新增加的功能合并进来

### DIFF
--- a/dead_pool_reaper_test.go
+++ b/dead_pool_reaper_test.go
@@ -33,13 +33,13 @@ func TestDeadPoolReaper(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = conn.Send("HMSET", redisKeyHeartbeat(ns, "2"),
-		"heartbeat_at", time.Now().Add(-1*time.Hour).Unix(),
+		"heartbeat_at", time.Now().Add(-1 * time.Hour).Unix(),
 		"job_names", "type1,type2",
 	)
 	assert.NoError(t, err)
 
 	err = conn.Send("HMSET", redisKeyHeartbeat(ns, "3"),
-		"heartbeat_at", time.Now().Add(-1*time.Hour).Unix(),
+		"heartbeat_at", time.Now().Add(-1 * time.Hour).Unix(),
 		"job_names", "type1,type2",
 	)
 	assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestDeadPoolReaper(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test getting dead pool
-	reaper := newDeadPoolReaper(ns, pool, []string{})
+	reaper := newDeadPoolReaper(ns, pool, []string{}, buildJobTypes("type1"))
 	deadPools, err := reaper.findDeadPools()
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]string{"2": {"type1", "type2"}, "3": {"type1", "type2"}}, deadPools)
@@ -126,7 +126,7 @@ func TestDeadPoolReaperNoHeartbeat(t *testing.T) {
 	assert.EqualValues(t, 3, numPools)
 
 	// Test getting dead pool ids
-	reaper := newDeadPoolReaper(ns, pool, []string{"type1"})
+	reaper := newDeadPoolReaper(ns, pool, []string{"type1"}, make(map[string]*jobType))
 	deadPools, err := reaper.findDeadPools()
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]string{"1": {}, "2": {}, "3": {}}, deadPools)
@@ -169,7 +169,7 @@ func TestDeadPoolReaperNoHeartbeat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, jobsCount)
 
-	// Stale lock info was cleaned up using reap.curJobTypes
+	// Stale lock info was cleaned up using reap.curJobNames
 	assert.EqualValues(t, 0, getInt64(pool, redisKeyJobsLock(ns, "type1")))
 	for _, poolID := range []string{"1", "2", "3"} {
 		v, _ := conn.Do("HGET", redisKeyJobsLockInfo(ns, "type1"), poolID)
@@ -195,12 +195,12 @@ func TestDeadPoolReaperNoJobTypes(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = conn.Send("HMSET", redisKeyHeartbeat(ns, "1"),
-		"heartbeat_at", time.Now().Add(-1*time.Hour).Unix(),
+		"heartbeat_at", time.Now().Add(-1 * time.Hour).Unix(),
 	)
 	assert.NoError(t, err)
 
 	err = conn.Send("HMSET", redisKeyHeartbeat(ns, "2"),
-		"heartbeat_at", time.Now().Add(-1*time.Hour).Unix(),
+		"heartbeat_at", time.Now().Add(-1 * time.Hour).Unix(),
 		"job_names", "type1,type2",
 	)
 	assert.NoError(t, err)
@@ -209,7 +209,7 @@ func TestDeadPoolReaperNoJobTypes(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test getting dead pool
-	reaper := newDeadPoolReaper(ns, pool, []string{})
+	reaper := newDeadPoolReaper(ns, pool, []string{}, buildJobTypes("type1"))
 	deadPools, err := reaper.findDeadPools()
 	assert.NoError(t, err)
 	assert.Equal(t, map[string][]string{"2": {"type1", "type2"}}, deadPools)
@@ -269,7 +269,7 @@ func TestDeadPoolReaperWithWorkerPools(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = conn.Do("LPUSH", redisKeyJobsInProgress(ns, stalePoolID, job1), `{"sleep": 10}`)
 	assert.NoError(t, err)
-	jobTypes := map[string]*jobType{"job1": nil}
+	jobTypes := map[string]*jobType{"job1": &jobType{JobOptions: JobOptions{RetryOnStart: true}}}
 	staleHeart := newWorkerPoolHeartbeater(ns, pool, stalePoolID, jobTypes, 1, []string{"id1"})
 	staleHeart.start()
 
@@ -278,8 +278,8 @@ func TestDeadPoolReaperWithWorkerPools(t *testing.T) {
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
 
 	// setup a worker pool and start the reaper, which should restart the stale job above
-	wp := setupTestWorkerPool(pool, ns, job1, 1, JobOptions{Priority: 1})
-	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, []string{"job1"})
+	wp := setupTestWorkerPool(pool, ns, job1, 1, JobOptions{Priority: 1, RetryOnStart: true})
+	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, []string{"job1"}, buildJobTypes("job1"))
 	wp.deadPoolReaper.deadTime = expectedDeadTime
 	wp.deadPoolReaper.start()
 
@@ -289,6 +289,19 @@ func TestDeadPoolReaperWithWorkerPools(t *testing.T) {
 	// now we should have 1 job in queue and no more stale jobs
 	assert.EqualValues(t, 1, listSize(pool, redisKeyJobs(ns, job1)))
 	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
+
+	// RetryOnStart: false, the job should be still in "in progress"
+	wp = setupTestWorkerPool(pool, ns, job1, 1, JobOptions{Priority: 1, RetryOnStart: false})
+	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, []string{"job1"}, map[string]*jobType{"job1": &jobType{JobOptions: JobOptions{RetryOnStart: false}}})
+	wp.deadPoolReaper.deadTime = expectedDeadTime
+	wp.deadPoolReaper.start()
+
+	// sleep long enough for staleJob to be considered dead
+	time.Sleep(expectedDeadTime * 2)
+
+	assert.EqualValues(t, 0, listSize(pool, redisKeyJobs(ns, job1)))
+	assert.EqualValues(t, 0, listSize(pool, redisKeyJobsInProgress(ns, wp.workerPoolID, job1)))
+
 	staleHeart.stop()
 	wp.deadPoolReaper.stop()
 }
@@ -323,7 +336,7 @@ func TestDeadPoolReaperCleanStaleLocks(t *testing.T) {
 	err = conn.Flush()
 	assert.NoError(t, err)
 
-	reaper := newDeadPoolReaper(ns, pool, jobNames)
+	reaper := newDeadPoolReaper(ns, pool, jobNames, make(map[string]*jobType))
 	// clean lock info for workerPoolID1
 	reaper.cleanStaleLockInfo(workerPoolID1, jobNames)
 	assert.NoError(t, err)
@@ -343,4 +356,8 @@ func TestDeadPoolReaperCleanStaleLocks(t *testing.T) {
 	assert.Nil(t, v)
 	v, err = conn.Do("HGET", lockInfo2, workerPoolID2)
 	assert.Nil(t, v)
+}
+
+func buildJobTypes(key string) map[string]*jobType {
+	return map[string]*jobType{key: &jobType{JobOptions: JobOptions{RetryOnStart: true}}}
 }

--- a/enqueue.go
+++ b/enqueue.go
@@ -67,10 +67,11 @@ func (e *Enqueuer) Enqueue(jobName string, args map[string]interface{}) (*Job, e
 // EnqueueIn enqueues a job in the scheduled job queue for execution in secondsFromNow seconds.
 func (e *Enqueuer) EnqueueIn(jobName string, secondsFromNow int64, args map[string]interface{}) (*ScheduledJob, error) {
 	job := &Job{
-		Name:       jobName,
-		ID:         makeIdentifier(),
-		EnqueuedAt: nowEpochSeconds(),
-		Args:       args,
+		Name:        jobName,
+		ID:          makeIdentifier(),
+		EnqueuedAt:  nowEpochSeconds(),
+		Args:        args,
+		ScheduledAt: nowEpochSeconds() + secondsFromNow,
 	}
 
 	rawJSON, err := job.serialize()
@@ -150,11 +151,12 @@ func (e *Enqueuer) EnqueueUniqueIn(jobName string, secondsFromNow int64, args ma
 	}
 
 	job := &Job{
-		Name:       jobName,
-		ID:         makeIdentifier(),
-		EnqueuedAt: nowEpochSeconds(),
-		Args:       args,
-		Unique:     true,
+		Name:        jobName,
+		ID:          makeIdentifier(),
+		EnqueuedAt:  nowEpochSeconds(),
+		Args:        args,
+		Unique:      true,
+		ScheduledAt: nowEpochSeconds() + secondsFromNow,
 	}
 
 	rawJSON, err := job.serialize()

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -116,7 +116,7 @@ func TestEnqueueUnique(t *testing.T) {
 		assert.NoError(t, job.ArgError())
 	}
 
-	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"})
+	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"}, WithExpireTime(400))
 	assert.NoError(t, err)
 	assert.Nil(t, job)
 

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -17,9 +17,9 @@ func TestEnqueue(t *testing.T) {
 	job, err := enqueuer.Enqueue("wat", Q{"a": 1, "b": "cool"})
 	assert.Nil(t, err)
 	assert.Equal(t, "wat", job.Name)
-	assert.True(t, len(job.ID) > 10)                        // Something is in it
-	assert.True(t, job.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-	assert.True(t, job.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.True(t, len(job.ID) > 10)                          // Something is in it
+	assert.True(t, job.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+	assert.True(t, job.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 	assert.Equal(t, "cool", job.ArgString("b"))
 	assert.EqualValues(t, 1, job.ArgInt64("a"))
 	assert.NoError(t, job.ArgError())
@@ -29,7 +29,7 @@ func TestEnqueue(t *testing.T) {
 
 	// Make sure the cache is set
 	expiresAt := enqueuer.knownJobs["wat"]
-	assert.True(t, expiresAt > (time.Now().Unix()+290))
+	assert.True(t, expiresAt > (time.Now().Unix() + 290))
 
 	// Make sure the length of the queue is 1
 	assert.EqualValues(t, 1, listSize(pool, redisKeyJobs(ns, "wat")))
@@ -37,9 +37,9 @@ func TestEnqueue(t *testing.T) {
 	// Get the job
 	j := jobOnQueue(pool, redisKeyJobs(ns, "wat"))
 	assert.Equal(t, "wat", j.Name)
-	assert.True(t, len(j.ID) > 10)                        // Something is in it
-	assert.True(t, j.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-	assert.True(t, j.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.True(t, len(j.ID) > 10)                          // Something is in it
+	assert.True(t, j.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+	assert.True(t, j.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 	assert.Equal(t, "cool", j.ArgString("b"))
 	assert.EqualValues(t, 1, j.ArgInt64("a"))
 	assert.NoError(t, j.ArgError())
@@ -64,9 +64,9 @@ func TestEnqueueIn(t *testing.T) {
 	assert.Nil(t, err)
 	if assert.NotNil(t, job) {
 		assert.Equal(t, "wat", job.Name)
-		assert.True(t, len(job.ID) > 10)                        // Something is in it
-		assert.True(t, job.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-		assert.True(t, job.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+		assert.True(t, len(job.ID) > 10)                          // Something is in it
+		assert.True(t, job.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+		assert.True(t, job.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 		assert.Equal(t, "cool", job.ArgString("b"))
 		assert.EqualValues(t, 1, job.ArgInt64("a"))
 		assert.NoError(t, job.ArgError())
@@ -78,7 +78,7 @@ func TestEnqueueIn(t *testing.T) {
 
 	// Make sure the cache is set
 	expiresAt := enqueuer.knownJobs["wat"]
-	assert.True(t, expiresAt > (time.Now().Unix()+290))
+	assert.True(t, expiresAt > (time.Now().Unix() + 290))
 
 	// Make sure the length of the scheduled job queue is 1
 	assert.EqualValues(t, 1, zsetSize(pool, redisKeyScheduled(ns)))
@@ -90,9 +90,9 @@ func TestEnqueueIn(t *testing.T) {
 	assert.True(t, score <= time.Now().Unix()+300)
 
 	assert.Equal(t, "wat", j.Name)
-	assert.True(t, len(j.ID) > 10)                        // Something is in it
-	assert.True(t, j.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-	assert.True(t, j.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.True(t, len(j.ID) > 10)                          // Something is in it
+	assert.True(t, j.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+	assert.True(t, j.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 	assert.Equal(t, "cool", j.ArgString("b"))
 	assert.EqualValues(t, 1, j.ArgInt64("a"))
 	assert.NoError(t, j.ArgError())
@@ -108,9 +108,9 @@ func TestEnqueueUnique(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.NotNil(t, job) {
 		assert.Equal(t, "wat", job.Name)
-		assert.True(t, len(job.ID) > 10)                        // Something is in it
-		assert.True(t, job.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-		assert.True(t, job.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+		assert.True(t, len(job.ID) > 10)                          // Something is in it
+		assert.True(t, job.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+		assert.True(t, job.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 		assert.Equal(t, "cool", job.ArgString("b"))
 		assert.EqualValues(t, 1, job.ArgInt64("a"))
 		assert.NoError(t, job.ArgError())
@@ -174,8 +174,84 @@ func TestEnqueueUnique(t *testing.T) {
 	assert.NotNil(t, job)
 }
 
+func TestEnqueueUniqueWithCustomKey(t *testing.T) {
+	pool := newTestPool(":6379")
+	ns := "work"
+	cleanKeyspace(ns, pool)
+	enqueuer := NewEnqueuer(ns, pool)
+	var mutex = &sync.Mutex{}
+	job, err := enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"}, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	if assert.NotNil(t, job) {
+		assert.Equal(t, "wat", job.Name)
+		assert.True(t, len(job.ID) > 10)                          // Something is in it
+		assert.True(t, job.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+		assert.True(t, job.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
+		assert.Equal(t, "cool", job.ArgString("b"))
+		assert.EqualValues(t, 1, job.ArgInt64("a"))
+		assert.NoError(t, job.ArgError())
+	}
+
+	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"}, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	assert.Nil(t, job)
+
+	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "coolio"})
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+
+	job, err = enqueuer.EnqueueUnique("wat", nil, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	assert.Nil(t, job)
+
+	job, err = enqueuer.EnqueueUnique("wat", nil, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	assert.Nil(t, job)
+
+	job, err = enqueuer.EnqueueUnique("taw", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+
+	// Process the queues. Ensure the right number of jobs were processed
+	var wats, taws int64
+	wp := NewWorkerPool(TestContext{}, 3, ns, pool)
+	wp.JobWithOptions("wat", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
+		mutex.Lock()
+		wats++
+		mutex.Unlock()
+		return nil
+	})
+	wp.JobWithOptions("taw", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
+		mutex.Lock()
+		taws++
+		mutex.Unlock()
+		return fmt.Errorf("ohno")
+	})
+	wp.Start()
+	wp.Drain()
+	wp.Stop()
+
+	assert.EqualValues(t, 2, wats)
+	assert.EqualValues(t, 1, taws)
+
+	// Enqueue again. Ensure we can.
+	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "cool"}, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+
+	job, err = enqueuer.EnqueueUnique("wat", Q{"a": 1, "b": "coolio"}, WithUniqueKey("unique_key"))
+	assert.NoError(t, err)
+	assert.Nil(t, job)
+
+	// Even though taw resulted in an error, we should still be able to re-queue it.
+	// This could result in multiple taws enqueued at the same time in a production system.
+	job, err = enqueuer.EnqueueUnique("taw", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, job)
+}
+
 // A job can be enqueued again only if after it is done, instead of just taking by a worker.
-func TestEnqueueUniqueAfterJobDone(t *testing.T){
+func TestEnqueueUniqueAfterJobDone(t *testing.T) {
 	pool := newTestPool(":6379")
 	ns := "work"
 	cleanKeyspace(ns, pool)
@@ -187,7 +263,7 @@ func TestEnqueueUniqueAfterJobDone(t *testing.T){
 	wp.JobWithOptions("wat", JobOptions{Priority: 1, MaxFails: 1}, func(job *Job) error {
 		mutex.Lock()
 		wats++
-		time.Sleep(time.Millisecond*100)
+		time.Sleep(time.Millisecond * 100)
 		mutex.Unlock()
 		return nil
 	})
@@ -200,7 +276,7 @@ func TestEnqueueUniqueAfterJobDone(t *testing.T){
 	// Start workers
 	assert.EqualValues(t, 0, wats)
 	wp.Start()
-	time.Sleep(time.Millisecond*10)
+	time.Sleep(time.Millisecond * 10)
 	assert.EqualValues(t, 1, wats)
 
 	// Same job is being processed, can not enqueue again.
@@ -231,9 +307,9 @@ func TestEnqueueUniqueIn(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.NotNil(t, job) {
 		assert.Equal(t, "wat", job.Name)
-		assert.True(t, len(job.ID) > 10)                        // Something is in it
-		assert.True(t, job.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-		assert.True(t, job.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+		assert.True(t, len(job.ID) > 10)                          // Something is in it
+		assert.True(t, job.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+		assert.True(t, job.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 		assert.Equal(t, "cool", job.ArgString("b"))
 		assert.EqualValues(t, 1, job.ArgInt64("a"))
 		assert.NoError(t, job.ArgError())
@@ -251,9 +327,9 @@ func TestEnqueueUniqueIn(t *testing.T) {
 	assert.True(t, score <= time.Now().Unix()+300)
 
 	assert.Equal(t, "wat", j.Name)
-	assert.True(t, len(j.ID) > 10)                        // Something is in it
-	assert.True(t, j.EnqueuedAt > (time.Now().Unix()-10)) // Within 10 seconds
-	assert.True(t, j.EnqueuedAt < (time.Now().Unix()+10)) // Within 10 seconds
+	assert.True(t, len(j.ID) > 10)                          // Something is in it
+	assert.True(t, j.EnqueuedAt > (time.Now().Unix() - 10)) // Within 10 seconds
+	assert.True(t, j.EnqueuedAt < (time.Now().Unix() + 10)) // Within 10 seconds
 	assert.Equal(t, "cool", j.ArgString("b"))
 	assert.EqualValues(t, 1, j.ArgInt64("a"))
 	assert.NoError(t, j.ArgError())

--- a/job.go
+++ b/job.go
@@ -10,11 +10,12 @@ import (
 // Job represents a job.
 type Job struct {
 	// Inputs when making a new job
-	Name       string                 `json:"name,omitempty"`
-	ID         string                 `json:"id"`
-	EnqueuedAt int64                  `json:"t"`
-	Args       map[string]interface{} `json:"args"`
-	Unique     bool                   `json:"unique,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	ID          string                 `json:"id"`
+	EnqueuedAt  int64                  `json:"t"`
+	Args        map[string]interface{} `json:"args"`
+	Unique      bool                   `json:"unique,omitempty"`
+	ScheduledAt int64                  `json:"s"`
 
 	// Inputs when retrying
 	Fails    int64  `json:"fails,omitempty"` // number of times this job has failed

--- a/log.go
+++ b/log.go
@@ -7,3 +7,7 @@ import (
 func logError(key string, err error) {
 	fmt.Printf("ERROR: %s - %s\n", key, err.Error())
 }
+
+func logInfo(format string, a ...interface{}) {
+	fmt.Printf("INFO: %s\n", fmt.Sprintf(format, a...))
+}

--- a/periodic_enqueuer.go
+++ b/periodic_enqueuer.go
@@ -100,8 +100,9 @@ func (pe *periodicEnqueuer) enqueue() error {
 				ID:   id,
 
 				// This is technically wrong, but this lets the bytes be identical for the same periodic job instance. If we don't do this, we'd need to use a different approach -- probably giving each periodic job its own history of the past 100 periodic jobs, and only scheduling a job if it's not in the history.
-				EnqueuedAt: epoch,
-				Args:       nil,
+				EnqueuedAt:  epoch,
+				Args:        nil,
+				ScheduledAt: epoch,
 			}
 
 			rawJSON, err := job.serialize()

--- a/periodic_enqueuer.go
+++ b/periodic_enqueuer.go
@@ -133,7 +133,7 @@ func (pe *periodicEnqueuer) shouldEnqueue() bool {
 		return true
 	}
 
-	return lastEnqueue < (nowEpochSeconds() - int64(periodicEnqueuerSleep/time.Minute))
+	return lastEnqueue < (nowEpochSeconds() - int64(periodicEnqueuerSleep/time.Second))
 }
 
 func makeUniquePeriodicID(name, spec string, epoch int64) string {

--- a/periodic_enqueuer_test.go
+++ b/periodic_enqueuer_test.go
@@ -91,7 +91,7 @@ func TestPeriodicEnqueuer(t *testing.T) {
 
 	assert.False(t, pe.shouldEnqueue())
 
-	setNowEpochSecondsMock(1468359454 + int64(periodicEnqueuerSleep/time.Minute) + 10)
+	setNowEpochSecondsMock(1468359454 + int64(periodicEnqueuerSleep/time.Second) + 10)
 
 	assert.True(t, pe.shouldEnqueue())
 }

--- a/redis.go
+++ b/redis.go
@@ -81,9 +81,13 @@ func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (
 	buf.WriteRune(':')
 
 	if args != nil {
-		err := json.NewEncoder(&buf).Encode(args)
-		if err != nil {
-			return "", err
+		if v, ok := args[UniqueKeyArg]; ok {
+			buf.WriteString(v.(string))
+		} else {
+			err := json.NewEncoder(&buf).Encode(args)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -347,9 +347,10 @@ return requeuedCount
 
 // KEYS[1] = job queue to push onto
 // KEYS[2] = Unique job's key. Test for existence and set if we push.
+// KEYS[3] = job expire time. Expired jobs can be enqueued again.
 // ARGV[1] = job
 var redisLuaEnqueueUnique = `
-if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then
+if redis.call('set', KEYS[2], '1', 'NX', 'EX', KEYS[3]) then
   redis.call('lpush', KEYS[1], ARGV[1])
   return 'ok'
 end
@@ -358,10 +359,11 @@ return 'dup'
 
 // KEYS[1] = scheduled job queue
 // KEYS[2] = Unique job's key. Test for existence and set if we push.
+// KEYS[3] = job expire time. Expired jobs can be enqueued again.
 // ARGV[1] = job
 // ARGV[2] = epoch seconds for job to be run at
 var redisLuaEnqueueUniqueIn = `
-if redis.call('set', KEYS[2], '1', 'NX', 'EX', '86400') then
+if redis.call('set', KEYS[2], '1', 'NX', 'EX', KEYS[3]) then
   redis.call('zadd', KEYS[1], ARGV[2], ARGV[1])
   return 'ok'
 end

--- a/run_test.go
+++ b/run_test.go
@@ -53,6 +53,80 @@ func TestRunBasicMiddleware(t *testing.T) {
 	assert.Equal(t, "mw1mw2mw3h1foo", c.String())
 }
 
+func TestRunBasicAndJobMiddleware(t *testing.T) {
+	mw1 := func(j *Job, next NextMiddlewareFunc) error {
+		j.setArg("mw1", "mw1")
+		return next()
+	}
+
+	mw2 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record(j.Args["mw1"].(string))
+		c.record("mw2")
+		next()
+		c.record("mw2")
+		return nil
+	}
+
+	mw3 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		next()
+		c.record("mw3")
+		return nil
+	}
+
+	jmw1 := func(j *Job, next NextMiddlewareFunc) error {
+		j.setArg("jmw1", "jmw1")
+		return next()
+	}
+
+	jmw2 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record(j.Args["jmw1"].(string))
+		c.record("jmw2")
+		next()
+		c.record("jmw2")
+		return nil
+	}
+
+	jmw3 := func(c *tstCtx, j *Job, next NextMiddlewareFunc) error {
+		c.record("jmw3")
+		return next()
+	}
+
+	h1 := func(c *tstCtx, j *Job) error {
+		c.record("h1")
+		c.record(j.Args["a"].(string))
+		return nil
+	}
+
+	middleware := []*middlewareHandler{
+		{IsGeneric: true, GenericMiddlewareHandler: mw1},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(mw2)},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(mw3)},
+	}
+
+	jobMiddleware := []*middlewareHandler{
+		{IsGeneric: true, GenericMiddlewareHandler: jmw1},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw2)},
+		{IsGeneric: false, DynamicMiddleware: reflect.ValueOf(jmw3)},
+	}
+
+	jt := &jobType{
+		Name:           "foo",
+		IsGeneric:      false,
+		DynamicHandler: reflect.ValueOf(h1),
+		middleware:     jobMiddleware,
+	}
+
+	job := &Job{
+		Name: "foo",
+		Args: map[string]interface{}{"a": "foo"},
+	}
+
+	v, err := runJob(job, tstCtxType, append(middleware, jt.middleware...), jt)
+	assert.NoError(t, err)
+	c := v.Interface().(*tstCtx)
+	assert.Equal(t, "mw1mw2jmw1jmw2jmw3h1foojmw2mw3mw2", c.String())
+}
+
 func TestRunHandlerError(t *testing.T) {
 	mw1 := func(j *Job, next NextMiddlewareFunc) error {
 		return next()

--- a/worker.go
+++ b/worker.go
@@ -184,9 +184,11 @@ func (w *worker) fetchJob() (*Job, error) {
 }
 
 func (w *worker) processJob(job *Job) {
-	if job.Unique {
-		w.deleteUniqueJob(job)
-	}
+	defer func() {
+		if job.Unique {
+			w.deleteUniqueJob(job)
+		}
+	}()
 	if jt, ok := w.jobTypes[job.Name]; ok {
 		w.observeStarted(job.Name, job.ID, job.Args)
 		job.observer = w.observer // for Checkin

--- a/worker.go
+++ b/worker.go
@@ -197,7 +197,8 @@ func (w *worker) processJob(job *Job) {
 		}
 		w.observeStarted(job.Name, job.ID, job.Args)
 		job.observer = w.observer // for Checkin
-		_, runErr := runJob(job, w.contextType, w.middleware, jt)
+		middleware := append(w.middleware, jt.middleware...)
+		_, runErr := runJob(job, w.contextType, middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
 
 		if runErr != nil {

--- a/worker.go
+++ b/worker.go
@@ -190,10 +190,16 @@ func (w *worker) processJob(job *Job) {
 		}
 	}()
 	if jt, ok := w.jobTypes[job.Name]; ok {
+		if jt.StartingDeadline > 0 && job.ScheduledAt > 0 && job.ScheduledAt < jt.StartingDeadline {
+			logInfo("Outdated! StartingDeadline: %d, ScheduledAt: %d, Job: %s\n", jt.StartingDeadline, job.ScheduledAt, job)
+			w.removeJobFromInProgress(job)
+			return
+		}
 		w.observeStarted(job.Name, job.ID, job.Args)
 		job.observer = w.observer // for Checkin
 		_, runErr := runJob(job, w.contextType, w.middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
+
 		if runErr != nil {
 			job.failed(runErr)
 			w.addToRetryOrDead(jt, job, runErr)

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -47,11 +47,12 @@ type BackoffCalculator func(job *Job) int64
 
 // JobOptions can be passed to JobWithOptions.
 type JobOptions struct {
-	Priority       uint              // Priority from 1 to 10000
-	MaxFails       uint              // 1: send straight to dead (unless SkipDead)
-	SkipDead       bool              // If true, don't send failed jobs to the dead queue when retries are exhausted.
-	MaxConcurrency uint              // Max number of jobs to keep in flight (default is 0, meaning no max)
-	Backoff        BackoffCalculator // If not set, uses the default backoff algorithm
+	Priority         uint              // Priority from 1 to 10000
+	MaxFails         uint              // 1: send straight to dead (unless SkipDead)
+	SkipDead         bool              // If true, don't send failed jobs to the dead queue when retries are exhausted.
+	MaxConcurrency   uint              // Max number of jobs to keep in flight (default is 0, meaning no max)
+	Backoff          BackoffCalculator // If not set, uses the default backoff algorithm
+	StartingDeadline int64             // UTC time in seconds(time.Now().Unix()), the deadline for starting the job if it misses its scheduled time for any reason
 }
 
 // GenericHandler is a job handler without any custom context.

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -37,6 +37,7 @@ type jobType struct {
 	IsGeneric      bool
 	GenericHandler GenericHandler
 	DynamicHandler reflect.Value
+	middleware     []*middlewareHandler
 }
 
 // You may provide your own backoff function for retrying failed jobs or use the builtin one.
@@ -101,19 +102,14 @@ func NewWorkerPool(ctx interface{}, concurrency uint, namespace string, pool *re
 // (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
 // func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
 func (wp *WorkerPool) Middleware(fn interface{}) *WorkerPool {
-	vfn := reflect.ValueOf(fn)
-	validateMiddlewareType(wp.contextType, vfn)
+	return wp.Middlewares([]interface{}{fn})
+}
 
-	mw := &middlewareHandler{
-		DynamicMiddleware: vfn,
-	}
-
-	if gmh, ok := fn.(func(*Job, NextMiddlewareFunc) error); ok {
-		mw.IsGeneric = true
-		mw.GenericMiddlewareHandler = gmh
-	}
-
-	wp.middleware = append(wp.middleware, mw)
+// Middlewares appends the specified functions to the middleware chain. The fn in fns can take one of these forms:
+// (*ContextType).func(*Job, NextMiddlewareFunc) error, (ContextType matches the type of ctx specified when creating a pool)
+// func(*Job, NextMiddlewareFunc) error, for the generic middleware format.
+func (wp *WorkerPool) Middlewares(fns []interface{}) *WorkerPool {
+	wp.middleware = funcToMiddleware(fns, wp.contextType)
 
 	for _, w := range wp.workers {
 		w.updateMiddlewareAndJobTypes(wp.middleware, wp.jobTypes)
@@ -127,20 +123,35 @@ func (wp *WorkerPool) Middleware(fn interface{}) *WorkerPool {
 // (*ContextType).func(*Job) error, (ContextType matches the type of ctx specified when creating a pool)
 // func(*Job) error, for the generic handler format.
 func (wp *WorkerPool) Job(name string, fn interface{}) *WorkerPool {
-	return wp.JobWithOptions(name, JobOptions{}, fn)
+	return wp.JobWithOptionsAndMiddlewares(name, JobOptions{}, fn, []interface{}{})
 }
 
 // JobWithOptions adds a handler for 'name' jobs as per the Job function, but permits you specify additional options
 // such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
 func (wp *WorkerPool) JobWithOptions(name string, jobOpts JobOptions, fn interface{}) *WorkerPool {
+	return wp.JobWithOptionsAndMiddlewares(name, jobOpts, fn, []interface{}{})
+}
+
+// JobWithMiddlewares adds middlewares for 'name' jobs as per the Job specified middlware chain
+func (wp *WorkerPool) JobWithMiddlewares(name string, fn interface{}, fns []interface{}) *WorkerPool {
+	return wp.JobWithOptionsAndMiddlewares(name, JobOptions{}, fn, fns)
+}
+
+// JobWithOptionsAndMiddlewares adds a handler for 'name' jobs as per the Job function, but permits you specify additional options
+// such as a job's priority, retry count, and whether to send dead jobs to the dead job queue or trash them.
+// And adds middlewares for 'name' jobs as per the Job specified middlware chain
+func (wp *WorkerPool) JobWithOptionsAndMiddlewares(name string, jobOpts JobOptions, fn interface{}, fns []interface{}) *WorkerPool {
 	jobOpts = applyDefaultsAndValidate(jobOpts)
 
 	vfn := reflect.ValueOf(fn)
 	validateHandlerType(wp.contextType, vfn)
+	jobMiddleware := funcToMiddleware(fns, wp.contextType)
+
 	jt := &jobType{
 		Name:           name,
 		DynamicHandler: vfn,
 		JobOptions:     jobOpts,
+		middleware:     jobMiddleware,
 	}
 	if gh, ok := fn.(func(*Job) error); ok {
 		jt.IsGeneric = true
@@ -282,6 +293,27 @@ func (wp *WorkerPool) writeConcurrencyControlsToRedis() {
 			logError("write_concurrency_controls_max_concurrency", err)
 		}
 	}
+}
+
+func funcToMiddleware(fns []interface{}, ctxType reflect.Type) []*middlewareHandler {
+	var middleware []*middlewareHandler
+	for _, fn := range fns {
+		vfn := reflect.ValueOf(fn)
+		validateMiddlewareType(ctxType, vfn)
+
+		mw := &middlewareHandler{
+			DynamicMiddleware: vfn,
+		}
+
+		if gmh, ok := fn.(func(*Job, NextMiddlewareFunc) error); ok {
+			mw.IsGeneric = true
+			mw.GenericMiddlewareHandler = gmh
+		}
+
+		middleware = append(middleware, mw)
+	}
+
+	return middleware
 }
 
 // validateContextType will panic if context is invalid

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -53,6 +53,7 @@ type JobOptions struct {
 	MaxConcurrency   uint              // Max number of jobs to keep in flight (default is 0, meaning no max)
 	Backoff          BackoffCalculator // If not set, uses the default backoff algorithm
 	StartingDeadline int64             // UTC time in seconds(time.Now().Unix()), the deadline for starting the job if it misses its scheduled time for any reason
+	RetryOnStart     bool              // If true, when a worker pool is started, jobs that are "in progress" will be retried
 }
 
 // GenericHandler is a job handler without any custom context.
@@ -235,7 +236,7 @@ func (wp *WorkerPool) startRequeuers() {
 	}
 	wp.retrier = newRequeuer(wp.namespace, wp.pool, redisKeyRetry(wp.namespace), jobNames)
 	wp.scheduler = newRequeuer(wp.namespace, wp.pool, redisKeyScheduled(wp.namespace), jobNames)
-	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, jobNames)
+	wp.deadPoolReaper = newDeadPoolReaper(wp.namespace, wp.pool, jobNames, wp.jobTypes)
 	wp.retrier.start()
 	wp.scheduler.start()
 	wp.deadPoolReaper.start()


### PR DESCRIPTION
1. 确保 enqueue unique job 在任务完成之后添加, 而非开始任务之前.
2. 解决 #69 issue, 增加对过期任务的一次性清理
3. 增加 RetryOnStart 的特性
4. 调整任务的默认超时时间从 1day 改为 10min, 同时增加可变任务超时的参数
5. 增加可自定义 unique key, 避免使用全部参数作为 key
6. 支持 fail without retry
7. 增加 job 指定的 middleware, 而不是 middelware 对应所有的 job.